### PR TITLE
Update base image refs to use competition fork images

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -15,14 +15,14 @@
 #
 ################################################################################
 
-docker build --pull -t gcr.io/oss-fuzz-base/base-image "$@" infra/base-images/base-image
-docker build -t gcr.io/oss-fuzz-base/base-clang "$@" infra/base-images/base-clang
-docker build -t gcr.io/oss-fuzz-base/base-builder "$@" infra/base-images/base-builder
-docker build -t gcr.io/oss-fuzz-base/base-builder-go "$@" infra/base-images/base-builder-go
-docker build -t gcr.io/oss-fuzz-base/base-builder-jvm "$@" infra/base-images/base-builder-jvm
-docker build -t gcr.io/oss-fuzz-base/base-builder-python "$@" infra/base-images/base-builder-python
-docker build -t gcr.io/oss-fuzz-base/base-builder-rust "$@" infra/base-images/base-builder-rust
-docker build -t gcr.io/oss-fuzz-base/base-builder-ruby "$@" infra/base-images/base-builder-ruby
-docker build -t gcr.io/oss-fuzz-base/base-builder-swift "$@" infra/base-images/base-builder-swift
-docker build -t gcr.io/oss-fuzz-base/base-runner "$@" infra/base-images/base-runner
-docker build -t gcr.io/oss-fuzz-base/base-runner-debug "$@" infra/base-images/base-runner-debug
+docker build --pull -t ghcr.io/aixcc-finals/base-image "$@" infra/base-images/base-image
+docker build -t ghcr.io/aixcc-finals/base-clang "$@" infra/base-images/base-clang
+docker build -t ghcr.io/aixcc-finals/base-builder "$@" infra/base-images/base-builder
+docker build -t ghcr.io/aixcc-finals/base-builder-go "$@" infra/base-images/base-builder-go
+docker build -t ghcr.io/aixcc-finals/base-builder-jvm "$@" infra/base-images/base-builder-jvm
+docker build -t ghcr.io/aixcc-finals/base-builder-python "$@" infra/base-images/base-builder-python
+docker build -t ghcr.io/aixcc-finals/base-builder-rust "$@" infra/base-images/base-builder-rust
+docker build -t ghcr.io/aixcc-finals/base-builder-ruby "$@" infra/base-images/base-builder-ruby
+docker build -t ghcr.io/aixcc-finals/base-builder-swift "$@" infra/base-images/base-builder-swift
+docker build -t ghcr.io/aixcc-finals/base-runner "$@" infra/base-images/base-runner
+docker build -t ghcr.io/aixcc-finals/base-runner-debug "$@" infra/base-images/base-runner-debug

--- a/infra/base-images/base-builder-fuzzbench/Dockerfile
+++ b/infra/base-images/base-builder-fuzzbench/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 # Copy/Run this now to make the cache more resilient.
 COPY fuzzbench_install_dependencies /usr/local/bin

--- a/infra/base-images/base-builder-fuzzbench/Dockerfile
+++ b/infra/base-images/base-builder-fuzzbench/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 # Copy/Run this now to make the cache more resilient.
 COPY fuzzbench_install_dependencies /usr/local/bin

--- a/infra/base-images/base-builder-go/Dockerfile
+++ b/infra/base-images/base-builder-go/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 # Set up Golang environment variables (copied from /root/.bash_profile).
 ENV GOPATH /root/go

--- a/infra/base-images/base-builder-go/Dockerfile
+++ b/infra/base-images/base-builder-go/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 # Set up Golang environment variables (copied from /root/.bash_profile).
 ENV GOPATH /root/go

--- a/infra/base-images/base-builder-javascript/Dockerfile
+++ b/infra/base-images/base-builder-javascript/Dockerfile
@@ -14,6 +14,6 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 RUN install_javascript.sh

--- a/infra/base-images/base-builder-javascript/Dockerfile
+++ b/infra/base-images/base-builder-javascript/Dockerfile
@@ -14,6 +14,7 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 RUN install_javascript.sh

--- a/infra/base-images/base-builder-jvm/Dockerfile
+++ b/infra/base-images/base-builder-jvm/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder AS base
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG} AS base
 
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME /usr/lib/jvm/java-15-openjdk-amd64

--- a/infra/base-images/base-builder-jvm/Dockerfile
+++ b/infra/base-images/base-builder-jvm/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder AS base
+FROM ghcr.io/aixcc-finals/base-builder AS base
 
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME /usr/lib/jvm/java-15-openjdk-amd64

--- a/infra/base-images/base-builder-python/Dockerfile
+++ b/infra/base-images/base-builder-python/Dockerfile
@@ -14,6 +14,6 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 RUN install_python.sh

--- a/infra/base-images/base-builder-python/Dockerfile
+++ b/infra/base-images/base-builder-python/Dockerfile
@@ -14,6 +14,7 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 RUN install_python.sh

--- a/infra/base-images/base-builder-ruby/Dockerfile
+++ b/infra/base-images/base-builder-ruby/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 RUN git clone https://github.com/trailofbits/ruzzy.git $SRC/ruzzy
 

--- a/infra/base-images/base-builder-ruby/Dockerfile
+++ b/infra/base-images/base-builder-ruby/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 RUN git clone https://github.com/trailofbits/ruzzy.git $SRC/ruzzy
 

--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 ENV CARGO_HOME=/rust
 ENV RUSTUP_HOME=/rust/rustup

--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 ENV CARGO_HOME=/rust
 ENV RUSTUP_HOME=/rust/rustup

--- a/infra/base-images/base-builder-swift/Dockerfile
+++ b/infra/base-images/base-builder-swift/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG}
 
 RUN install_swift.sh
 

--- a/infra/base-images/base-builder-swift/Dockerfile
+++ b/infra/base-images/base-builder-swift/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 RUN install_swift.sh
 

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-clang
+FROM ghcr.io/aixcc-finals/base-clang
 
 COPY install_deps.sh /
 RUN /install_deps.sh && rm /install_deps.sh

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-clang
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-clang:${IMG_TAG}
 
 COPY install_deps.sh /
 RUN /install_deps.sh && rm /install_deps.sh

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -16,7 +16,8 @@
 
 # Docker image with clang installed.
 
-FROM ghcr.io/aixcc-finals/base-image
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-image:${IMG_TAG}
 
 ARG arch=x86_64
 

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -16,7 +16,7 @@
 
 # Docker image with clang installed.
 
-FROM gcr.io/oss-fuzz-base/base-image
+FROM ghcr.io/aixcc-finals/base-image
 
 ARG arch=x86_64
 

--- a/infra/base-images/base-runner-debug/Dockerfile
+++ b/infra/base-images/base-runner-debug/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM ghcr.io/aixcc-finals/base-runner
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-runner:${IMG_TAG}
 RUN apt-get update && apt-get install -y valgrind zip
 
 # Installing GDB 12, re https://github.com/google/oss-fuzz/issues/7513.

--- a/infra/base-images/base-runner-debug/Dockerfile
+++ b/infra/base-images/base-runner-debug/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-runner
+FROM ghcr.io/aixcc-finals/base-runner
 RUN apt-get update && apt-get install -y valgrind zip
 
 # Installing GDB 12, re https://github.com/google/oss-fuzz/issues/7513.

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -16,22 +16,23 @@
 
 # Build rust stuff in its own image. We only need the resulting binaries.
 # Keeping the rust toolchain in the image wastes 1 GB.
-FROM ghcr.io/aixcc-finals/base-image as temp-runner-binary-builder
+ARG IMG_TAG=latest
+FROM ghcr.io/aixcc-finals/base-image:${IMG_TAG} as temp-runner-binary-builder
 
 RUN apt-get update && apt-get install -y cargo libyaml-dev
 RUN cargo install rustfilt
 
 # Using multi-stage build to copy some LLVM binaries needed in the runner image.
-FROM ghcr.io/aixcc-finals/base-clang AS base-clang
-FROM ghcr.io/aixcc-finals/base-builder-ruby AS base-ruby
+FROM ghcr.io/aixcc-finals/base-clang:${IMG_TAG} AS base-clang
+FROM ghcr.io/aixcc-finals/base-builder-ruby:${IMG_TAG} AS base-ruby
 
 # The base builder image compiles a specific Python version. Using a multi-stage build
 # to copy that same Python interpreter into the runner image saves build time and keeps
 # the Python versions in sync.
-FROM ghcr.io/aixcc-finals/base-builder AS base-builder
+FROM ghcr.io/aixcc-finals/base-builder:${IMG_TAG} AS base-builder
 
 # Real image that will be used later.
-FROM ghcr.io/aixcc-finals/base-image
+FROM ghcr.io/aixcc-finals/base-image:${IMG_TAG}
 
 COPY --from=temp-runner-binary-builder /root/.cargo/bin/rustfilt /usr/local/bin
 

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -16,22 +16,22 @@
 
 # Build rust stuff in its own image. We only need the resulting binaries.
 # Keeping the rust toolchain in the image wastes 1 GB.
-FROM gcr.io/oss-fuzz-base/base-image as temp-runner-binary-builder
+FROM ghcr.io/aixcc-finals/base-image as temp-runner-binary-builder
 
 RUN apt-get update && apt-get install -y cargo libyaml-dev
 RUN cargo install rustfilt
 
 # Using multi-stage build to copy some LLVM binaries needed in the runner image.
-FROM gcr.io/oss-fuzz-base/base-clang AS base-clang
-FROM gcr.io/oss-fuzz-base/base-builder-ruby AS base-ruby
+FROM ghcr.io/aixcc-finals/base-clang AS base-clang
+FROM ghcr.io/aixcc-finals/base-builder-ruby AS base-ruby
 
 # The base builder image compiles a specific Python version. Using a multi-stage build
 # to copy that same Python interpreter into the runner image saves build time and keeps
 # the Python versions in sync.
-FROM gcr.io/oss-fuzz-base/base-builder AS base-builder
+FROM ghcr.io/aixcc-finals/base-builder AS base-builder
 
 # Real image that will be used later.
-FROM gcr.io/oss-fuzz-base/base-image
+FROM ghcr.io/aixcc-finals/base-image
 
 COPY --from=temp-runner-binary-builder /root/.cargo/bin/rustfilt /usr/local/bin
 

--- a/infra/base-images/base-runner/README.md
+++ b/infra/base-images/base-runner/README.md
@@ -2,7 +2,7 @@
 > Base image for fuzzer runners.
 
 ```bash
-docker run -ti gcr.io/oss-fuzz-base/base-runner <command> <args>
+docker run -ti ghcr.io/aixcc-finals/base-runner <command> <args>
 ```
 
 ## Commands

--- a/infra/build/build_status/Dockerfile
+++ b/infra/build/build_status/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-runner
+FROM ghcr.io/aixcc-finals/base-runner
 
 RUN mkdir -p /opt/oss-fuzz/infra/build_status
 COPY infra/build/functions/* /opt/oss-fuzz/infra/build_status/

--- a/infra/build/build_status/cloudbuild.yaml
+++ b/infra/build/build_status/cloudbuild.yaml
@@ -3,11 +3,11 @@ steps:
   args:
   - build
   - '-t'
-  - gcr.io/oss-fuzz-base/build-status
+  - ghcr.io/aixcc-finals/build-status
   - '-f'
   - infra/build/build_status/Dockerfile
   - .
-- name: 'gcr.io/oss-fuzz-base/build-status'
+- name: 'ghcr.io/aixcc-finals/build-status'
   args: []
   timeout: 14400s
 options:

--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -40,7 +40,7 @@ BASE_PROJECT = 'oss-fuzz-base'
 TAG_PREFIX = f'gcr.io/{BASE_PROJECT}/'
 MAJOR_TAG = 'v1'
 MANIFEST_IMAGES = [
-    'gcr.io/oss-fuzz-base/base-builder', 'gcr.io/oss-fuzz-base/base-runner'
+    'ghcr.io/aixcc-finals/base-builder', 'ghcr.io/aixcc-finals/base-runner'
 ]
 TIMEOUT = str(6 * 60 * 60)
 

--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -37,7 +37,7 @@ BASE_IMAGES = [
     'base-runner-debug',
 ]
 BASE_PROJECT = 'aixcc-finals'
-TAG_PREFIX = f'gcr.io/{BASE_PROJECT}/'
+TAG_PREFIX = f'ghcr.io/{BASE_PROJECT}/'
 MAJOR_TAG = 'v1'
 MANIFEST_IMAGES = [
     'ghcr.io/aixcc-finals/base-builder', 'ghcr.io/aixcc-finals/base-runner'

--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -36,7 +36,7 @@ BASE_IMAGES = [
     'base-runner',
     'base-runner-debug',
 ]
-BASE_PROJECT = 'oss-fuzz-base'
+BASE_PROJECT = 'aixcc-finals'
 TAG_PREFIX = f'gcr.io/{BASE_PROJECT}/'
 MAJOR_TAG = 'v1'
 MANIFEST_IMAGES = [

--- a/infra/build/functions/build_and_push_test_images.py
+++ b/infra/build/functions/build_and_push_test_images.py
@@ -28,7 +28,7 @@ import yaml
 import base_images
 import build_lib
 
-CLOUD_PROJECT = 'oss-fuzz-base'
+CLOUD_PROJECT = 'aixcc-finals'
 INFRA_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 IMAGES_DIR = os.path.join(INFRA_DIR, 'base-images')
 OSS_FUZZ_ROOT = os.path.dirname(INFRA_DIR)
@@ -71,7 +71,7 @@ def _run_cloudbuild(build_body):
     yaml.dump(build_body, yaml_file_handle)
 
   subprocess.run([
-      'gcloud', 'builds', 'submit', '--project=oss-fuzz-base',
+      'gcloud', 'builds', 'submit', '--project=aixcc-finals',
       f'--config={yaml_file}'
   ],
                  cwd=OSS_FUZZ_ROOT,

--- a/infra/build/functions/build_and_push_test_images.py
+++ b/infra/build/functions/build_and_push_test_images.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-"""Script for building and pushing base-images to gcr.io/oss-fuzz-base/ with
+"""Script for building and pushing base-images to ghcr.io/aixcc-finals/ with
 "-test" suffix. This is useful for using the build infra to test image
 changes."""
 import logging

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -267,7 +267,7 @@ def download_coverage_data_steps(project_name, latest, bucket_name, out_dir):
     return None
 
   steps.append({
-      'name': 'gcr.io/oss-fuzz-base/base-runner',
+      'name': 'ghcr.io/aixcc-finals/base-runner',
       'args': ['bash', '-c', (f'mkdir -p {out_dir}/textcov_reports')]
   })
 
@@ -279,7 +279,7 @@ def download_coverage_data_steps(project_name, latest, bucket_name, out_dir):
       'allowFailure': True
   })
   steps.append({
-      'name': 'gcr.io/oss-fuzz-base/base-runner',
+      'name': 'ghcr.io/aixcc-finals/base-runner',
       'args': ['bash', '-c', f'ls -lrt {out_dir}/textcov_reports'],
       'allowFailure': True
   })
@@ -322,16 +322,16 @@ def get_pull_test_images_steps(test_image_suffix):
   """Returns steps to pull testing versions of base-images and tag them so that
   they are used in builds."""
   images = [
-      'gcr.io/oss-fuzz-base/base-builder',
-      'gcr.io/oss-fuzz-base/base-builder-swift',
-      'gcr.io/oss-fuzz-base/base-builder-javascript',
-      'gcr.io/oss-fuzz-base/base-builder-jvm',
-      'gcr.io/oss-fuzz-base/base-builder-go',
-      'gcr.io/oss-fuzz-base/base-builder-python',
-      'gcr.io/oss-fuzz-base/base-builder-ruby',
-      'gcr.io/oss-fuzz-base/base-builder-rust',
-      'gcr.io/oss-fuzz-base/base-builder-ruby',
-      'gcr.io/oss-fuzz-base/base-runner',
+      'ghcr.io/aixcc-finals/base-builder',
+      'ghcr.io/aixcc-finals/base-builder-swift',
+      'ghcr.io/aixcc-finals/base-builder-javascript',
+      'ghcr.io/aixcc-finals/base-builder-jvm',
+      'ghcr.io/aixcc-finals/base-builder-go',
+      'ghcr.io/aixcc-finals/base-builder-python',
+      'ghcr.io/aixcc-finals/base-builder-ruby',
+      'ghcr.io/aixcc-finals/base-builder-rust',
+      'ghcr.io/aixcc-finals/base-builder-ruby',
+      'ghcr.io/aixcc-finals/base-runner',
   ]
   steps = []
   for image in images:
@@ -346,11 +346,11 @@ def get_pull_test_images_steps(test_image_suffix):
     })
 
     # This step is hacky but gives us great flexibility. OSS-Fuzz has hardcoded
-    # references to gcr.io/oss-fuzz-base/base-builder (in dockerfiles, for
-    # example) and gcr.io/oss-fuzz-base-runner (in this build code). But the
+    # references to ghcr.io/aixcc-finals/base-builder (in dockerfiles, for
+    # example) and ghcr.io/aixcc-finals-runner (in this build code). But the
     # testing versions of those images are called e.g.
-    # gcr.io/oss-fuzz-base/base-builder-testing and
-    # gcr.io/oss-fuzz-base/base-runner-testing. How can we get the build to use
+    # ghcr.io/aixcc-finals/base-builder-testing and
+    # ghcr.io/aixcc-finals/base-runner-testing. How can we get the build to use
     # the testing images instead of the real ones? By doing this step: tagging
     # the test image with the non-test version, so that the test version is used
     # instead of pulling the real one.

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -544,7 +544,7 @@ def get_gcb_url(build_id, cloud_project='oss-fuzz'):
 def get_runner_image_name(test_image_suffix):
   """Returns the runner image that should be used. Returns the testing image if
   |test_image_suffix|."""
-  image = f'gcr.io/{BASE_IMAGES_PROJECT}/base-runner'
+  image = f'ghcr.io/{BASE_IMAGES_PROJECT}/base-runner'
   if test_image_suffix:
     image += '-' + test_image_suffix
   return image

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -35,7 +35,7 @@ from oauth2client import service_account as service_account_lib
 import requests
 import yaml
 
-BASE_IMAGES_PROJECT = 'oss-fuzz-base'
+BASE_IMAGES_PROJECT = 'aixcc-finals'
 IMAGE_PROJECT = 'oss-fuzz'
 
 BUILD_TIMEOUT = 20 * 60 * 60

--- a/infra/build/functions/fuzzbench.py
+++ b/infra/build/functions/fuzzbench.py
@@ -31,7 +31,7 @@ FUZZBENCH_PATH = '/fuzzbench'
 def get_engine_project_image(fuzzing_engine, project):
   """Returns the name of an image used to build |project| with
   |fuzzing_engine|."""
-  return f'gcr.io/oss-fuzz-base/{fuzzing_engine}/{project.name}'
+  return f'ghcr.io/aixcc-finals/{fuzzing_engine}/{project.name}'
 
 
 def get_env(project, build):
@@ -128,14 +128,14 @@ def get_build_steps(  # pylint: disable=too-many-locals, too-many-arguments
       },
       {
           'name': 'gcr.io/cloud-builders/docker',
-          'args': ['pull', 'gcr.io/oss-fuzz-base/base-builder-fuzzbench']
+          'args': ['pull', 'ghcr.io/aixcc-finals/base-builder-fuzzbench']
       },
       {  # TODO(metzman): Don't overwrite base-builder
           'name':
               'gcr.io/cloud-builders/docker',
           'args': [
-              'tag', 'gcr.io/oss-fuzz-base/base-builder-fuzzbench',
-              'gcr.io/oss-fuzz-base/base-builder'
+              'tag', 'ghcr.io/aixcc-finals/base-builder-fuzzbench',
+              'ghcr.io/aixcc-finals/base-builder'
           ]
       },
   ]

--- a/infra/build/functions/request_build.py
+++ b/infra/build/functions/request_build.py
@@ -23,7 +23,7 @@ import yaml
 import build_project
 import datastore_entities
 
-BASE_PROJECT = 'oss-fuzz-base'
+BASE_PROJECT = 'aixcc-finals'
 MAX_BUILD_HISTORY_LENGTH = 64
 QUEUE_TTL_SECONDS = 60 * 60 * 24  # 24 hours.
 

--- a/infra/build/functions/request_coverage_build.py
+++ b/infra/build/functions/request_coverage_build.py
@@ -22,7 +22,7 @@ from google.cloud import ndb
 import build_and_run_coverage
 import request_build
 
-BASE_PROJECT = 'oss-fuzz-base'
+BASE_PROJECT = 'aixcc-finals'
 
 
 def get_build_steps(project_name):

--- a/infra/build/functions/request_introspector_build.py
+++ b/infra/build/functions/request_introspector_build.py
@@ -22,7 +22,7 @@ from google.cloud import ndb
 import build_and_run_coverage
 import request_build
 
-BASE_PROJECT = 'oss-fuzz-base'
+BASE_PROJECT = 'aixcc-finals'
 
 
 # TODO (navidem): write test, currently tested manually.

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -124,7 +124,7 @@ def run_experiment(project_name,
 
   run_step = {
       'name':
-          'gcr.io/oss-fuzz-base/base-runner',
+          'ghcr.io/aixcc-finals/base-runner',
       'env':
           env,
       'args': [

--- a/infra/build/functions/test_data/expected_build_steps.json
+++ b/infra/build/functions/test_data/expected_build_steps.json
@@ -147,7 +147,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine afl --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine afl --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -155,7 +155,7 @@
     "id": "build-check-afl-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=afl",
@@ -179,21 +179,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/afl-address-x86_64/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -288,7 +288,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine centipede --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine centipede --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -296,7 +296,7 @@
     "id": "build-check-centipede-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=centipede",
@@ -320,21 +320,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/centipede-address-x86_64/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -429,7 +429,7 @@
       "-e",
       "SANITIZER=none",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer none --engine centipede --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer none --engine centipede --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -437,7 +437,7 @@
     "id": "build-check-centipede-none-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=centipede",
@@ -461,21 +461,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/centipede-none-x86_64/test-project-none-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.none",
       "test_url"
@@ -570,7 +570,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine honggfuzz --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine honggfuzz --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -578,7 +578,7 @@
     "id": "build-check-honggfuzz-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=honggfuzz",
@@ -602,21 +602,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/honggfuzz-address-x86_64/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -711,7 +711,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -719,7 +719,7 @@
     "id": "build-check-libfuzzer-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=libfuzzer",
@@ -743,21 +743,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/libfuzzer-address-x86_64/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -852,7 +852,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture i386 test-project\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture i386 test-project\n********************************************************************************\" && false)"
@@ -860,7 +860,7 @@
     "id": "build-check-libfuzzer-address-i386"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=i386",
       "FUZZING_ENGINE=libfuzzer",
@@ -884,21 +884,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/libfuzzer-address-i386/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -993,7 +993,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture aarch64 test-project\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture aarch64 test-project\n********************************************************************************\" && false)"
@@ -1001,7 +1001,7 @@
     "id": "build-check-libfuzzer-address-aarch64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=aarch64",
       "FUZZING_ENGINE=libfuzzer",
@@ -1025,21 +1025,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/libfuzzer-address-aarch64/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -1134,7 +1134,7 @@
       "-e",
       "SANITIZER=memory",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer memory --engine libfuzzer --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer memory --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -1142,7 +1142,7 @@
     "id": "build-check-libfuzzer-memory-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=libfuzzer",
@@ -1166,21 +1166,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/libfuzzer-memory-x86_64/test-project-memory-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.memory",
       "test_url"
@@ -1275,7 +1275,7 @@
       "-e",
       "SANITIZER=undefined",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer undefined --engine libfuzzer --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer undefined --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -1283,7 +1283,7 @@
     "id": "build-check-libfuzzer-undefined-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=libfuzzer",
@@ -1307,21 +1307,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/libfuzzer-undefined-x86_64/test-project-undefined-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.undefined",
       "test_url"

--- a/infra/build/functions/test_data/expected_centipede_build_steps.json
+++ b/infra/build/functions/test_data/expected_centipede_build_steps.json
@@ -103,7 +103,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine centipede --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine centipede --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -111,7 +111,7 @@
     "id": "build-check-centipede-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=centipede",
@@ -135,21 +135,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/centipede-address-x86_64/test-project-address-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.address",
       "test_url"
@@ -244,7 +244,7 @@
       "-e",
       "SANITIZER=none",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner",
+      "ghcr.io/aixcc-finals/base-runner",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer none --engine centipede --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer none --engine centipede --architecture x86_64 test-project\n********************************************************************************\" && false)"
@@ -252,7 +252,7 @@
     "id": "build-check-centipede-none-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=centipede",
@@ -276,21 +276,21 @@
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/srcmap.json",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/out/centipede-none-x86_64/test-project-none-202001010000.zip",
       "test_url"
     ]
   },
   {
-    "name": "gcr.io/oss-fuzz-base/uploader",
+    "name": "ghcr.io/aixcc-finals/uploader",
     "args": [
       "/workspace/targets.list.none",
       "test_url"

--- a/infra/build/functions/test_data/expected_coverage_build_steps.json
+++ b/infra/build/functions/test_data/expected_coverage_build_steps.json
@@ -76,7 +76,7 @@
     "url": "test_download"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "name": "ghcr.io/aixcc-finals/base-runner",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=libfuzzer",

--- a/infra/build/functions/test_data/expected_trial_build_steps.json
+++ b/infra/build/functions/test_data/expected_trial_build_steps.json
@@ -14,7 +14,7 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -22,15 +22,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder"
+      "ghcr.io/aixcc-finals/base-builder-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-swift-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-swift-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -38,15 +38,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-swift-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-swift"
+      "ghcr.io/aixcc-finals/base-builder-swift-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-swift"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-javascript-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-javascript-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -54,15 +54,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-javascript-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-javascript"
+      "ghcr.io/aixcc-finals/base-builder-javascript-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-javascript"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-jvm-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-jvm-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -70,15 +70,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-jvm-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-jvm"
+      "ghcr.io/aixcc-finals/base-builder-jvm-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-jvm"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-go-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-go-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -86,15 +86,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-go-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-go"
+      "ghcr.io/aixcc-finals/base-builder-go-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-go"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-python-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-python-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -102,22 +102,22 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-python-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-python"
+      "ghcr.io/aixcc-finals/base-builder-python-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-python"
     ]
   },
-  {"args": ["pull", "gcr.io/oss-fuzz-base/base-builder-ruby-testing-mybranch"],
+  {"args": ["pull", "ghcr.io/aixcc-finals/base-builder-ruby-testing-mybranch"],
    "name": "gcr.io/cloud-builders/docker",
    "waitFor": "-"},
   {"args": ["tag",
-            "gcr.io/oss-fuzz-base/base-builder-ruby-testing-mybranch",
-            "gcr.io/oss-fuzz-base/base-builder-ruby"],
+            "ghcr.io/aixcc-finals/base-builder-ruby-testing-mybranch",
+            "ghcr.io/aixcc-finals/base-builder-ruby"],
    "name": "gcr.io/cloud-builders/docker"},
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-rust-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-rust-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -125,15 +125,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-rust-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-rust"
+      "ghcr.io/aixcc-finals/base-builder-rust-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-rust"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-builder-ruby-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-builder-ruby-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -141,15 +141,15 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-builder-ruby-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-builder-ruby"
+      "ghcr.io/aixcc-finals/base-builder-ruby-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-builder-ruby"
     ]
   },
   {
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "pull",
-      "gcr.io/oss-fuzz-base/base-runner-testing-mybranch"
+      "ghcr.io/aixcc-finals/base-runner-testing-mybranch"
     ],
     "waitFor": "-"
   },
@@ -157,8 +157,8 @@
     "name": "gcr.io/cloud-builders/docker",
     "args": [
       "tag",
-      "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
-      "gcr.io/oss-fuzz-base/base-runner"
+      "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-runner"
     ]
   },
   {
@@ -256,7 +256,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image skcms\npython infra/helper.py build_fuzzers --sanitizer address --engine afl --architecture x86_64 skcms\npython infra/helper.py check_build --sanitizer address --engine afl --architecture x86_64 skcms\n********************************************************************************\" && false)"
@@ -264,7 +264,7 @@
     "id": "build-check-afl-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+    "name": "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=afl",
@@ -348,7 +348,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image skcms\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 skcms\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture x86_64 skcms\n********************************************************************************\" && false)"
@@ -356,7 +356,7 @@
     "id": "build-check-libfuzzer-address-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+    "name": "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=libfuzzer",
@@ -440,7 +440,7 @@
       "-e",
       "SANITIZER=address",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image skcms\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture i386 skcms\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture i386 skcms\n********************************************************************************\" && false)"
@@ -448,7 +448,7 @@
     "id": "build-check-libfuzzer-address-i386"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+    "name": "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
     "env": [
       "ARCHITECTURE=i386",
       "FUZZING_ENGINE=libfuzzer",
@@ -532,7 +532,7 @@
       "-e",
       "SANITIZER=undefined",
       "-t",
-      "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+      "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
       "bash",
       "-c",
       "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image skcms\npython infra/helper.py build_fuzzers --sanitizer undefined --engine libfuzzer --architecture x86_64 skcms\npython infra/helper.py check_build --sanitizer undefined --engine libfuzzer --architecture x86_64 skcms\n********************************************************************************\" && false)"
@@ -540,7 +540,7 @@
     "id": "build-check-libfuzzer-undefined-x86_64"
   },
   {
-    "name": "gcr.io/oss-fuzz-base/base-runner-testing-mybranch",
+    "name": "ghcr.io/aixcc-finals/base-runner-testing-mybranch",
     "env": [
       "ARCHITECTURE=x86_64",
       "FUZZING_ENGINE=libfuzzer",

--- a/infra/build/functions/trial_build/cloudbuild.yaml
+++ b/infra/build/functions/trial_build/cloudbuild.yaml
@@ -3,11 +3,11 @@ steps:
   args:
   - build
   - '-t'
-  - gcr.io/oss-fuzz-base/trial-build
+  - ghcr.io/aixcc-finals/trial-build
   - '-f'
   - infra/build/functions/trial_build/Dockerfile
   - .
-- name: 'gcr.io/oss-fuzz-base/trial-build'
+- name: 'ghcr.io/aixcc-finals/trial-build'
   args: []
   env:
     - 'PULL_REQUEST_NUMBER=${_PR_NUMBER}'

--- a/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
+++ b/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
@@ -4,14 +4,14 @@ steps:
   args:
   - 'build'
   - '-t'
-  - 'gcr.io/oss-fuzz-base/fuzz-introspector-webapp'
+  - 'ghcr.io/aixcc-finals/fuzz-introspector-webapp'
   - 'infra/build/fuzz-introspector-webapp'
 
 # Push the image here so we deploy the latest build.
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'push'
-  - 'gcr.io/oss-fuzz-base/fuzz-introspector-webapp'
+  - 'ghcr.io/aixcc-finals/fuzz-introspector-webapp'
 
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: gcloud
@@ -20,7 +20,7 @@ steps:
     - 'deploy'
     - 'fuzz-introspector-webapp'
     - '--image'
-    - 'gcr.io/oss-fuzz-base/fuzz-introspector-webapp'
+    - 'ghcr.io/aixcc-finals/fuzz-introspector-webapp'
     - '--region'
     - 'us-central1'
     - '--min-instances'

--- a/infra/build_fuzzers.Dockerfile
+++ b/infra/build_fuzzers.Dockerfile
@@ -16,7 +16,7 @@
 # Docker image to run fuzzers for CIFuzz (the run_fuzzers action on GitHub
 # actions).
 
-FROM gcr.io/oss-fuzz-base/cifuzz-base
+FROM ghcr.io/aixcc-finals/cifuzz-base
 
 # Python file to execute when the docker container starts up
 # We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,

--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -110,7 +110,7 @@ def _replace_base_builder_digest(dockerfile_path, digest):
   new_lines = []
   for line in lines:
     if line.strip().startswith('FROM'):
-      line = 'FROM gcr.io/oss-fuzz-base/base-builder@' + digest + '\n'
+      line = 'FROM ghcr.io/aixcc-finals/base-builder@' + digest + '\n'
 
     new_lines.append(line)
 
@@ -346,7 +346,7 @@ def load_base_builder_repo():
       'container',
       'images',
       'list-tags',
-      'gcr.io/oss-fuzz-base/base-builder',
+      'ghcr.io/aixcc-finals/base-builder',
       '--format=json',
       '--sort-by=timestamp',
   ],

--- a/infra/cifuzz/base_runner_utils.py
+++ b/infra/cifuzz/base_runner_utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Utilities for scripts from gcr.io/oss-fuzz-base/base-runner."""
+"""Utilities for scripts from ghcr.io/aixcc-finals/base-runner."""
 
 import os
 

--- a/infra/cifuzz/build-images.sh
+++ b/infra/cifuzz/build-images.sh
@@ -21,14 +21,14 @@ INFRA_DIR=$(realpath $CIFUZZ_DIR/..)
 OSS_FUZZ_ROOT=$(realpath $INFRA_DIR/..)
 
 # Build cifuzz-base.
-docker build --tag gcr.io/oss-fuzz-base/cifuzz-base --file $CIFUZZ_DIR/cifuzz-base/Dockerfile $OSS_FUZZ_ROOT
+docker build --tag ghcr.io/aixcc-finals/cifuzz-base --file $CIFUZZ_DIR/cifuzz-base/Dockerfile $OSS_FUZZ_ROOT
 
 # Build run-fuzzers and build-fuzzers images.
 docker build \
-  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers-test:v1 \
-  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1 \
+  --tag ghcr.io/aixcc-finals/clusterfuzzlite-build-fuzzers-test:v1 \
+  --tag ghcr.io/aixcc-finals/clusterfuzzlite-build-fuzzers:v1 \
   --file $INFRA_DIR/build_fuzzers.Dockerfile $INFRA_DIR
 docker build \
-  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1 \
-  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers-test:v1 \
+  --tag ghcr.io/aixcc-finals/clusterfuzzlite-run-fuzzers:v1 \
+  --tag ghcr.io/aixcc-finals/clusterfuzzlite-run-fuzzers-test:v1 \
   --file $INFRA_DIR/run_fuzzers.Dockerfile $INFRA_DIR

--- a/infra/cifuzz/cifuzz-base/Dockerfile
+++ b/infra/cifuzz/cifuzz-base/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-runner
+FROM ghcr.io/aixcc-finals/base-runner
 
 RUN apt-get update && \
     apt-get install -y systemd && \

--- a/infra/cifuzz/cloudbuild.yaml
+++ b/infra/cifuzz/cloudbuild.yaml
@@ -4,9 +4,9 @@ steps:
   args:
   - build
   - '-t'
-  - gcr.io/oss-fuzz-base/cifuzz-base
+  - ghcr.io/aixcc-finals/cifuzz-base
   - '-t'
-  - gcr.io/oss-fuzz-base/cifuzz-base:v1
+  - ghcr.io/aixcc-finals/cifuzz-base:v1
   - '-f'
   - infra/cifuzz/cifuzz-base/Dockerfile
   - .
@@ -14,13 +14,13 @@ steps:
   args:
   - build
   - '-t'
-  - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers
+  - ghcr.io/aixcc-finals/cifuzz-build-fuzzers
   - '-t'
-  - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers:v1
+  - ghcr.io/aixcc-finals/cifuzz-build-fuzzers:v1
   - '-t'
-  - gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers
+  - ghcr.io/aixcc-finals/clusterfuzzlite-build-fuzzers
   - '-t'
-  - gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1
+  - ghcr.io/aixcc-finals/clusterfuzzlite-build-fuzzers:v1
   - '-f'
   - infra/build_fuzzers.Dockerfile
   - infra
@@ -28,25 +28,25 @@ steps:
   args:
   - build
   - '-t'
-  - gcr.io/oss-fuzz-base/cifuzz-run-fuzzers
+  - ghcr.io/aixcc-finals/cifuzz-run-fuzzers
   - '-t'
-  - gcr.io/oss-fuzz-base/cifuzz-run-fuzzers:v1
+  - ghcr.io/aixcc-finals/cifuzz-run-fuzzers:v1
   - '-t'
-  - gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers
+  - ghcr.io/aixcc-finals/clusterfuzzlite-run-fuzzers
   - '-t'
-  - gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1
+  - ghcr.io/aixcc-finals/clusterfuzzlite-run-fuzzers:v1
   - '-f'
   - infra/run_fuzzers.Dockerfile
   - infra
 images:
-- gcr.io/oss-fuzz-base/cifuzz-base
-- gcr.io/oss-fuzz-base/cifuzz-base:v1
-- gcr.io/oss-fuzz-base/cifuzz-run-fuzzers
-- gcr.io/oss-fuzz-base/cifuzz-run-fuzzers:v1
-- gcr.io/oss-fuzz-base/cifuzz-build-fuzzers
-- gcr.io/oss-fuzz-base/cifuzz-build-fuzzers:v1
-- gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers
-- gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1
-- gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers
-- gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1
+- ghcr.io/aixcc-finals/cifuzz-base
+- ghcr.io/aixcc-finals/cifuzz-base:v1
+- ghcr.io/aixcc-finals/cifuzz-run-fuzzers
+- ghcr.io/aixcc-finals/cifuzz-run-fuzzers:v1
+- ghcr.io/aixcc-finals/cifuzz-build-fuzzers
+- ghcr.io/aixcc-finals/cifuzz-build-fuzzers:v1
+- ghcr.io/aixcc-finals/clusterfuzzlite-build-fuzzers
+- ghcr.io/aixcc-finals/clusterfuzzlite-build-fuzzers:v1
+- ghcr.io/aixcc-finals/clusterfuzzlite-run-fuzzers
+- ghcr.io/aixcc-finals/clusterfuzzlite-run-fuzzers:v1
 timeout: 1800s

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -24,7 +24,7 @@ import constants
 import utils
 import environment
 
-BASE_BUILDER_TAG = 'gcr.io/oss-fuzz-base/base-builder'
+BASE_BUILDER_TAG = 'ghcr.io/aixcc-finals/base-builder'
 PROJECT_TAG_PREFIX = 'gcr.io/oss-fuzz/'
 
 # Default fuzz configuration.

--- a/infra/cifuzz/run_cifuzz.py
+++ b/infra/cifuzz/run_cifuzz.py
@@ -21,7 +21,7 @@ import logging
 
 INFRA_DIR = os.path.dirname(os.path.dirname(__file__))
 DEFAULT_ENVS = [('DRY_RUN', '0'), ('SANITIZER', 'address')]
-BASE_CIFUZZ_DOCKER_TAG = 'gcr.io/oss-fuzz-base'
+BASE_CIFUZZ_DOCKER_TAG = 'ghcr.io/aixcc-finals'
 
 
 def set_default_env_var_if_unset(env_var, default_value):

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -351,7 +351,7 @@ class CoverageReportIntegrationTest(unittest.TestCase):
                       'cp $(which llvm-profdata) /shared && '
                       'cp $(which llvm-cov) /shared')
       assert helper.docker_run([
-          '-v', f'{shared}:/shared', 'gcr.io/oss-fuzz-base/base-runner', 'bash',
+          '-v', f'{shared}:/shared', 'ghcr.io/aixcc-finals/base-runner', 'bash',
           '-c', copy_command
       ])
 
@@ -376,7 +376,7 @@ class CoverageReportIntegrationTest(unittest.TestCase):
 
       assert helper.docker_run([
           '-v', f'{os.path.join(temp_dir, "build-out")}:/out',
-          'gcr.io/oss-fuzz-base/base-builder', 'bash', '-c', chmod_command
+          'ghcr.io/aixcc-finals/base-builder', 'bash', '-c', chmod_command
       ])
 
       # Generate report.

--- a/infra/cifuzz/test_data/external-project/.clusterfuzzlite/Dockerfile
+++ b/infra/cifuzz/test_data/external-project/.clusterfuzzlite/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 RUN apt-get update && apt-get install -y make
 
 COPY . $SRC/external-project

--- a/infra/experimental/SystemSan/PoEs/node-shell-quote-v1.7.3/Dockerfile
+++ b/infra/experimental/SystemSan/PoEs/node-shell-quote-v1.7.3/Dockerfile
@@ -14,7 +14,7 @@
 #
 # Build and run the proof of error in shell-quote v1.7.3.
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM ghcr.io/aixcc-finals/base-builder
 
 RUN apt update && \
   apt install -y \

--- a/infra/experimental/SystemSan/PoEs/pytorch-lightning-1.5.10/Dockerfile
+++ b/infra/experimental/SystemSan/PoEs/pytorch-lightning-1.5.10/Dockerfile
@@ -14,7 +14,7 @@
 #
 # Build and run the proof of error in pytorch-lightning.
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM ghcr.io/aixcc-finals/base-builder-python
 
 RUN apt update && \
   apt install -y vim && \

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -37,23 +37,23 @@ import templates
 OSS_FUZZ_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 BUILD_DIR = os.path.join(OSS_FUZZ_DIR, 'build')
 
-BASE_RUNNER_IMAGE = 'gcr.io/oss-fuzz-base/base-runner'
+BASE_RUNNER_IMAGE = 'ghcr.io/aixcc-finals/base-runner'
 
 BASE_IMAGES = {
     'generic': [
-        'gcr.io/oss-fuzz-base/base-image',
-        'gcr.io/oss-fuzz-base/base-clang',
-        'gcr.io/oss-fuzz-base/base-builder',
+        'ghcr.io/aixcc-finals/base-image',
+        'ghcr.io/aixcc-finals/base-clang',
+        'ghcr.io/aixcc-finals/base-builder',
         BASE_RUNNER_IMAGE,
-        'gcr.io/oss-fuzz-base/base-runner-debug',
+        'ghcr.io/aixcc-finals/base-runner-debug',
     ],
-    'go': ['gcr.io/oss-fuzz-base/base-builder-go'],
-    'javascript': ['gcr.io/oss-fuzz-base/base-builder-javascript'],
-    'jvm': ['gcr.io/oss-fuzz-base/base-builder-jvm'],
-    'python': ['gcr.io/oss-fuzz-base/base-builder-python'],
-    'rust': ['gcr.io/oss-fuzz-base/base-builder-rust'],
-    'ruby': ['gcr.io/oss-fuzz-base/base-builder-ruby'],
-    'swift': ['gcr.io/oss-fuzz-base/base-builder-swift'],
+    'go': ['ghcr.io/aixcc-finals/base-builder-go'],
+    'javascript': ['ghcr.io/aixcc-finals/base-builder-javascript'],
+    'jvm': ['ghcr.io/aixcc-finals/base-builder-jvm'],
+    'python': ['ghcr.io/aixcc-finals/base-builder-python'],
+    'rust': ['ghcr.io/aixcc-finals/base-builder-rust'],
+    'ruby': ['ghcr.io/aixcc-finals/base-builder-ruby'],
+    'swift': ['ghcr.io/aixcc-finals/base-builder-swift'],
 }
 
 VALID_PROJECT_NAME_REGEX = re.compile(r'^[a-zA-Z0-9_-]+$')
@@ -94,7 +94,7 @@ ARM_BUILDER_NAME = 'oss-fuzz-buildx-builder'
 CLUSTERFUZZLITE_ENGINE = 'libfuzzer'
 CLUSTERFUZZLITE_ARCHITECTURE = 'x86_64'
 CLUSTERFUZZLITE_FILESTORE_DIR = 'filestore'
-CLUSTERFUZZLITE_DOCKER_IMAGE = 'gcr.io/oss-fuzz-base/cifuzz-run-fuzzers'
+CLUSTERFUZZLITE_DOCKER_IMAGE = 'ghcr.io/aixcc-finals/cifuzz-run-fuzzers'
 
 logger = logging.getLogger(__name__)
 
@@ -904,7 +904,7 @@ def run_clusterfuzzlite(args):
         shutil.copytree(args.project.path, project_src_path)
 
       build_command = [
-          '--tag', 'gcr.io/oss-fuzz-base/cifuzz-run-fuzzers', '--file',
+          '--tag', 'ghcr.io/aixcc-finals/cifuzz-run-fuzzers', '--file',
           'infra/run_fuzzers.Dockerfile', 'infra'
       ]
       if not docker_build(build_command):
@@ -1000,8 +1000,8 @@ def fuzzbench_build_fuzzers(args):
     ]
     tag = f'gcr.io/oss-fuzz/{args.project.name}'
     subprocess.run([
-        'docker', 'tag', 'gcr.io/oss-fuzz-base/base-builder-fuzzbench',
-        'gcr.io/oss-fuzz-base/base-builder'
+        'docker', 'tag', 'ghcr.io/aixcc-finals/base-builder-fuzzbench',
+        'ghcr.io/aixcc-finals/base-builder'
     ],
                    check=True)
     build_image_impl(args.project)
@@ -1572,7 +1572,7 @@ def reproduce_impl(  # pylint: disable=too-many-arguments
       '-v',
       '%s:/testcase' % _get_absolute_path(testcase_path),
       '-t',
-      'gcr.io/oss-fuzz-base/%s' % image_name,
+      'ghcr.io/aixcc-finals/%s' % image_name,
       'reproduce',
       fuzzer_name,
       '-runs=100',

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -641,7 +641,7 @@ def build_image_impl(project, cache=True, pull=False, architecture='x86_64'):
   image_name = project.name
 
   if is_base_image(image_name):
-    image_project = 'oss-fuzz-base'
+    image_project = 'aixcc-finals'
     docker_build_dir = os.path.join(OSS_FUZZ_DIR, 'infra', 'base-images',
                                     image_name)
     dockerfile_path = os.path.join(docker_build_dir, 'Dockerfile')
@@ -1694,7 +1694,7 @@ def shell(args):
     env += args.e
 
   if is_base_image(args.project.name):
-    image_project = 'oss-fuzz-base'
+    image_project = 'aixcc-finals'
     out_dir = _get_out_dir()
   else:
     image_project = 'oss-fuzz'

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -645,18 +645,19 @@ def build_image_impl(project, cache=True, pull=False, architecture='x86_64'):
     docker_build_dir = os.path.join(OSS_FUZZ_DIR, 'infra', 'base-images',
                                     image_name)
     dockerfile_path = os.path.join(docker_build_dir, 'Dockerfile')
+    image_name = 'ghcr.io/%s/%s' % (image_project, image_name)
   else:
     if not check_project_exists(project):
       return False
     dockerfile_path = project.dockerfile_path
     docker_build_dir = project.path
     image_project = 'oss-fuzz'
+    image_name = 'gcr.io/%s/%s' % (image_project, image_name)
 
   if pull and not pull_images(project.language):
     return False
 
   build_args = []
-  image_name = 'gcr.io/%s/%s' % (image_project, image_name)
   if architecture == 'aarch64':
     build_args += [
         'buildx',
@@ -1695,9 +1696,11 @@ def shell(args):
 
   if is_base_image(args.project.name):
     image_project = 'aixcc-finals'
+    image_addr = 'ghcr.io/%s/%s' % (image_project, args.project.name)
     out_dir = _get_out_dir()
   else:
     image_project = 'oss-fuzz'
+    image_addr = 'gcr.io/%s/%s' % (image_project, args.project.name)
     out_dir = args.project.out
 
   run_args = _env_to_docker_args(env)
@@ -1712,7 +1715,7 @@ def shell(args):
       '-v',
       '%s:/out' % out_dir, '-v',
       '%s:/work' % args.project.work, '-t',
-      'gcr.io/%s/%s' % (image_project, args.project.name), '/bin/bash'
+      '%s' % image_addr, '/bin/bash'
   ])
 
   docker_run(run_args, architecture=args.architecture)

--- a/infra/helper_test.py
+++ b/infra/helper_test.py
@@ -71,7 +71,7 @@ class BuildImageImplTest(unittest.TestCase):
     build_dir = os.path.join(helper.OSS_FUZZ_DIR,
                              'infra/base-images/base-image')
     mock_docker_build.assert_called_with([
-        '-t', 'gcr.io/oss-fuzz-base/base-image', '--file',
+        '-t', 'ghcr.io/aixcc-finals/base-image', '--file',
         os.path.join(build_dir, 'Dockerfile'), build_dir
     ])
 

--- a/infra/manifest.py
+++ b/infra/manifest.py
@@ -51,7 +51,7 @@ def main():
   subprocess.run(['gcloud', 'projects', 'list', '--limit=1'], check=True)
 
   images = [
-      'gcr.io/oss-fuzz-base/base-builder', 'gcr.io/oss-fuzz-base/base-runner'
+      'ghcr.io/aixcc-finals/base-builder', 'ghcr.io/aixcc-finals/base-runner'
   ]
   results = [push_manifest(image) for image in images]
   return 0 if all(results) else 1

--- a/infra/run_fuzzers.Dockerfile
+++ b/infra/run_fuzzers.Dockerfile
@@ -16,7 +16,7 @@
 # Docker image for running fuzzers on CIFuzz (the run_fuzzers action on GitHub
 # actions).
 
-FROM gcr.io/oss-fuzz-base/cifuzz-base
+FROM ghcr.io/aixcc-finals/cifuzz-base
 
 # Python file to execute when the docker container starts up.
 # We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -40,7 +40,7 @@ DOCKER_TEMPLATE = """\
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/%(base_builder)s
+FROM ghcr.io/aixcc-finals/%(base_builder)s
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 <git_url> %(project_name)s     # or use other version control
 WORKDIR %(project_name)s
@@ -48,7 +48,7 @@ COPY build.sh $SRC/
 """
 
 EXTERNAL_DOCKER_TEMPLATE = """\
-FROM gcr.io/oss-fuzz-base/%(base_builder)s:v1
+FROM ghcr.io/aixcc-finals/%(base_builder)s:v1
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 COPY . $SRC/%(project_name)s
 WORKDIR %(project_name)s

--- a/infra/tools/hold_back_images.py
+++ b/infra/tools/hold_back_images.py
@@ -93,7 +93,7 @@ def hold_image(project, hold_image_digest, update_held, issue_number):
   with open(dockerfile_path, 'r') as dockerfile_handle:
     dockerfile = dockerfile_handle.readlines()
   for idx, line in enumerate(dockerfile[:]):
-    if not line.startswith('FROM gcr.io/oss-fuzz-base/base-builder'):
+    if not line.startswith('FROM ghcr.io/aixcc-finals/base-builder'):
       continue
 
     hold_image_digest, should_hold = get_hold_image_digest(

--- a/infra/tools/hold_back_images.py
+++ b/infra/tools/hold_back_images.py
@@ -28,7 +28,7 @@ PROJECTS_DIR = os.path.join(ROOT_DIR, 'projects')
 
 IMAGE_DIGEST_REGEX = re.compile(r'\[(.+)\]\n')
 FROM_LINE_REGEX = re.compile(
-    r'FROM (gcr.io\/oss-fuzz-base\/base-builder[\-a-z0-9]*)(\@?.*)')
+    r'FROM (gcr.io\/aixcc-finals\/base-builder[\-a-z0-9]*)(\@?.*)')
 
 
 def get_latest_docker_image_digest(image):

--- a/infra/tools/hold_back_images.py
+++ b/infra/tools/hold_back_images.py
@@ -28,7 +28,7 @@ PROJECTS_DIR = os.path.join(ROOT_DIR, 'projects')
 
 IMAGE_DIGEST_REGEX = re.compile(r'\[(.+)\]\n')
 FROM_LINE_REGEX = re.compile(
-    r'FROM (gcr.io\/aixcc-finals\/base-builder[\-a-z0-9]*)(\@?.*)')
+    r'FROM (ghcr.io\/aixcc-finals\/base-builder[\-a-z0-9]*)(\@?.*)')
 
 
 def get_latest_docker_image_digest(image):

--- a/tools/vscode-extension/src/projectIntegrationHelper.ts
+++ b/tools/vscode-extension/src/projectIntegrationHelper.ts
@@ -292,10 +292,10 @@ function getLicenseHeader() {
 
 function getBaseDockerFile(language: string) {
   const languageToBasebuilder: {[id: string]: string} = {
-    java: 'gcr.io/oss-fuzz-base/base-builder-jvm',
-    cpp: 'gcr.io/oss-fuzz-base/base-builder',
-    c: 'gcr.io/oss-fuzz-base/base-builder',
-    python: 'gcr.io/oss-fuzz-base/base-builder-python',
+    java: 'ghcr.io/aixcc-finals/base-builder-jvm',
+    cpp: 'ghcr.io/aixcc-finals/base-builder',
+    c: 'ghcr.io/aixcc-finals/base-builder',
+    python: 'ghcr.io/aixcc-finals/base-builder-python',
   };
   let dockerFileContent = getLicenseHeader();
   dockerFileContent += '\n' + 'FROM ' + languageToBasebuilder[language] + '\n';
@@ -428,7 +428,7 @@ RUN git clone --depth 1 ${projectGithubRepository} ${projectNameFromRepo}
 WORKDIR ${projectNameFromRepo}
 COPY build.sh *.cpp $SRC/`;
 
-    const dockerfileTemplateClusterfuzzLite = `FROM gcr.io/oss-fuzz-base/base-builder
+    const dockerfileTemplateClusterfuzzLite = `FROM ghcr.io/aixcc-finals/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 COPY . $SRC/${baseName}
@@ -548,7 +548,7 @@ RUN git clone --depth 1 ${projectGithubRepository} ${projectNameFromRepo}
 WORKDIR ${projectNameFromRepo}
 COPY build.sh *.cpp $SRC/`;
 
-    const dockerfileTemplateClusterfuzzLite = `FROM gcr.io/oss-fuzz-base/base-builder
+    const dockerfileTemplateClusterfuzzLite = `FROM ghcr.io/aixcc-finals/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 COPY . $SRC/${baseName}


### PR DESCRIPTION
This updates all base image refs (outside the projects directory) to point to our competition fork base images.