### PR TITLE
Fix image cache naming differences on release

### DIFF
--- a/.github/workflows/build_and_upload_images.yml
+++ b/.github/workflows/build_and_upload_images.yml
@@ -39,7 +39,8 @@ jobs:
     - name: Build and upload based on release cache, update cache
       if: github.event_name == 'push'
       run: |
-        infra/base-images/aixcc_build_all.sh --cache-to "${{ github.ref }}" "${{ github.sha }}"
+        BRANCH_NAME="${{ github.ref }}"
+        infra/base-images/aixcc_build_all.sh --cache-to "${BRANCH_NAME#refs/heads/}" "${{ github.sha }}"
 
     - name: Build and upload based on release cache, no cache update
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
Fixes difference between github.ref and github.base_ref prefix, causing PRs into release branches to not use the proper cache.